### PR TITLE
Update for other platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,30 +1,21 @@
 ---
-# Set ~/.aws/credentials file for access keys
-# $AWS_SSH_KEY_ID to specify what key to use
-driver:
-  name: ec2
+driver_plugin: vagrant
+driver_config:
   require_chef_omnibus: 12.6.0
-  security_group_ids: ["sg-68ce330c"]
-  subnet_id: subnet-2f5f9f04
-  region: us-east-1
-  availability_zone: e
-  instance_type: m3.medium
-  image_id: ami-74b3e11c
-  iam_profile_name: TestKitchenRole
-  associate_public_ip: false
-  interface: private
-
-transport:
-  ssh_key: ~/.ssh/kp-2011-05-02.pem
-  username: ubuntu
-
+  customize:
+    natdnshostresolver1: "on"
+    memory: 2048
 provisioner: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
+- name: ubuntu-14.04
+  driver_config:
+    box: opscode_ubuntu-14.04_chef-provisionerless
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
 
 suites:
 - name: default
+  data_bags_path: "test/integration/data_bags"
   encrypted_data_bag_secret_key_path: "test/integration/encrypted_data_bag_secret"
   run_list:
     - recipe[optoro_aptly::repos]
@@ -36,6 +27,7 @@ suites:
       compile_time_update: true
 
 - name: consul
+  data_bags_path: "test/integration/data_bags"
   encrypted_data_bag_secret_key_path: "test/integration/encrypted_data_bag_secret"
   run_list:
     - recipe[optoro_aptly::repos]

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,3 @@
 source 'http://berks-api.optoro.io'
 
 metadata
-
-cookbook 'optoro_aptly'
-cookbook 'optoro_logstash'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'foodcritic-rules-optoro'
   gem 'chefspec', '~> 4.5.0'
   gem 'rspec', '~> 3.4.0'
+  gem 'rspec-retry', '~> 0.4.5'
   gem 'thor'
   gem 'rubocop', '~> 0.35.1'
   gem 'knife-solo', '0.4.2'

--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -1,0 +1,13 @@
+# Example --config S3 values
+default['exhibitor']['cli']['configtype'] = 's3'
+default['exhibitor']['cli']['s3config'] = "optoro-exhibitor:#{node.chef_environment}"
+default['exhibitor']['cli']['s3region'] = 'us-east-1'
+
+if node['ec2']
+  s3_creds = query_role_credentials # ~FC044
+else
+  s3_creds = Chef::EncryptedDataBagItem.load('credentials', 's3')
+end
+
+default['exhibitor']['s3']['access_key_id'] = s3_creds['AccessKeyId']
+default['exhibitor']['s3']['access_secret_key'] = s3_creds['SecretAccessKey']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,16 @@
 # Example --config S3 values
-node.default!['exhibitor']['cli']['configtype'] = 's3'
-default['exhibitor']['s3']['key'] = ''
-default['exhibitor']['s3']['secret'] = ''
+default['exhibitor']['s3']['key'] = 'KEY'
+default['exhibitor']['s3']['secret'] = 'SECRET'
 default['exhibitor']['cli']['s3config'] = "optoro-exhibitor:#{node.chef_environment}"
 default['exhibitor']['cli']['s3region'] = 'us-east-1'
-node.default!['zookeeper']['group'] = 'zookeeper'
+force_default['zookeeper']['group'] = 'zookeeper'
 override['zookeeper']['mirror'] = 'https://archive.apache.org/dist/zookeeper'
 
 # Consul
 default['optoro_consul']['register_consul_service'] = false
+default['consul']['version'] = '0.6.3'
+default['consul']['base_url'] = "https://releases.hashicorp.com/consul/#{node['consul']['version']}/consul_%{version}.zip"
+default['consul']['checksums'] = {
+  '0.6.3_linux_amd64' => 'b0532c61fec4a4f6d130c893fd8954ec007a6ad93effbe283a39224ed237e250',
+  '0.6.3_web_ui' => '93bbb300cacfe8de90fb3bd5ede7d37ae6ce014898edc520b9c96a676b2bbb72'
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'Installs and configures Zookeeper using exhibitor'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.13'
+version '0.0.14'
 
 supports 'ubuntu', '= 14.04'
 
@@ -12,7 +12,10 @@ provides 'optoro_zookeeper::default'
 recipe 'optoro_zookeeper::default', 'Installs Zookeeper the Optoro way'
 
 depends 'apt'
-depends 'exhibitor', '>= 0.4.0'
-depends 'zookeeper', '>= 2.4.1'
 depends 'aws', '~> 2.5.3'
+depends 'consul', '~> 0.7.1'
+depends 'exhibitor', '>= 0.4.0'
+depends 'optoro_aptly'
 depends 'optoro_consul'
+depends 'optoro_logstash'
+depends 'zookeeper', '>= 2.4.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,22 +32,16 @@ node.default['exhibitor']['config']['servers_spec'] = zookeepers.join(',')
 
 include_recipe 'apt'
 include_recipe 'exhibitor'
-include_recipe 'exhibitor::service'
 include_recipe 'zookeeper'
-include_recipe 'aws'
+include_recipe 'aws' if node['ec2']
 include_recipe 'optoro_zookeeper::consul' if node['optoro_consul']['register_consul_service']
-
-s3_creds = query_role_credentials
-node.default!['exhibitor']['s3']['access_key_id'] = s3_creds['AccessKeyId']
-node.default!['exhibitor']['s3']['access_secret_key'] = s3_creds['SecretAccessKey']
-node.default!['exhibitor']['cli']['configtype'] = 's3'
 
 # We hard code using exhibitor to bring up ZK nodes
 node.default['zookeeper']['service_style'] = 'exhibitor'
 
 zookeeper '3.4.6' do
   user 'zookeeper'
-  mirror 'http://apache.mirrors.hoobly.com/zookeeper/'
+  mirror node['zookeeper']['mirror']
   checksum '01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994'
   action :install
 end
@@ -69,3 +63,5 @@ file ::File.join(node['exhibitor']['install_dir'], 'exhibitor.s3.properties') do
   content(render_s3_credentials(node['exhibitor']['s3']))
   action :create
 end
+
+include_recipe 'exhibitor::service'

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -1,1 +1,5 @@
 node.set['fqdn'] = 'test-zookeeper-001.optoro.com'
+node.force_override['consul']['service_mode'] = 'bootstrap' # ~FC019
+node.force_override['consul']['enable_syslog'] = false # ~FC019
+
+package 'curl'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -39,9 +39,6 @@ describe 'optoro_zookeeper::default' do
         it 'includes zookeeper::default' do
           expect(chef_run).to include_recipe('zookeeper::default')
         end
-        it 'includes aws::default' do
-          expect(chef_run).to include_recipe('aws::default')
-        end
         it 'creates /var/lib/zookeeper' do
           expect(chef_run).to create_directory('/var/lib/zookeeper').with(user: 'zookeeper', group: 'zookeeper', mode: '0755')
         end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -2,5 +2,10 @@ shared_context 'optoro_zookeeper' do
   before do
     Chef::Recipe.any_instance.stub(:query_role).and_return('kitchen_role')
     Chef::Recipe.any_instance.stub(:query_role_credentials).and_return('{ "Code" : "Success", "LastUpdated" : "2015-03-09T14:48:17Z", "Type" : "AWS-HMAC", "AccessKeyId" : "ACCESSKEY", "SecretAccessKey" : "SECRETKEY", "Token" : "TOKEN", "Expiration" : "2015-03-09T21:14:00Z" }')
+    allow(Chef::EncryptedDataBagItem).to receive(:load).and_return(
+      'id' => 's3',
+      'AccessKeyId' => 'ACCESSKEY',
+      'SecretAccessKey' => 'SECRETKEY'
+    )
   end
 end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -8,6 +8,10 @@ describe 'optoro_zookeeper::test' do
           ChefSpec::ServerRunner.new(platform: platform, version: version, log_level: :error) do |_node|
           end.converge(described_recipe)
         end
+
+        it 'installs curl' do
+          expect(chef_run).to install_package('curl')
+        end
       end
     end
   end

--- a/test/integration/consul/serverspec/Gemfile
+++ b/test/integration/consul/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+source 'http://gems.optoro.io/'
+gem 'rspec-retry'

--- a/test/integration/consul/serverspec/consul_service_spec.rb
+++ b/test/integration/consul/serverspec/consul_service_spec.rb
@@ -14,12 +14,12 @@ describe 'Consul Service' do
     it { should be_listening }
   end
 
-  it 'should be registered as master' do
+  it 'should be registered as master', retry: 5, retry_wait: 10 do
     expect(command('curl http://localhost:8500/v1/catalog/service/zookeeper').stdout)
       .to match(/zookeeper/)
   end
 
-  it 'should have a passing health check' do
+  it 'should have a passing health check', retry: 5, retry_wait: 10 do
     expect(command('curl http://localhost:8500/v1/health/checks/zookeeper').stdout)
       .to match(/passing/)
   end

--- a/test/integration/consul/serverspec/spec_helper.rb
+++ b/test/integration/consul/serverspec/spec_helper.rb
@@ -1,5 +1,11 @@
 # coding: utf-8
 require 'serverspec'
 require 'pathname'
+require 'rspec/retry'
+
+RSpec.configure do |config|
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+end
 
 set :backend, :exec

--- a/test/integration/data_bags/credentials/s3.json
+++ b/test/integration/data_bags/credentials/s3.json
@@ -1,0 +1,15 @@
+{
+  "id": "s3",
+  "AccessKeyId": {
+    "encrypted_data": "JxGGxK15foPUT8hWfouVKpm6gWJtw3XJJx1nH1tc9Z8cQLbfUS5BHc9QWlVV\nxxWh\n",
+    "iv": "f77gG6TtRJDhSrLe2DJSXA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
+  },
+  "SecretAccessKey": {
+    "encrypted_data": "/yvaGpv/ztJ3dJ/GiUAjJD9VZl3AjSzuqYTIiCj22CskANep1Nt+TVVkEH3m\nVK59\n",
+    "iv": "2xzhFAr9mVlEGV8p5pUb3w==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
+  }
+}


### PR DESCRIPTION
These changes make the cookbook suitable for other platforms:

* Tests can be conducted on e.g. Vagrant, Joyent, etc.
* Make sure the correct consul cookbook is being used (an old version)
* Fix tests by making the test instance run its own consul server